### PR TITLE
Do not use with-helm-show-completion

### DIFF
--- a/helm-company.el
+++ b/helm-company.el
@@ -163,11 +163,9 @@ It is useful to narrow candidates."
   (unless company-candidates
     (company-complete))
   (when company-point
-    (let ((begin (- company-point (length company-prefix))))
-      (with-helm-show-completion begin company--point-max
-        (helm :sources 'helm-source-company
-              :buffer  "*helm company*"
-              :candidate-number-limit helm-company-candidate-number-limit)))))
+    (helm :sources 'helm-source-company
+          :buffer  "*helm company*"
+          :candidate-number-limit helm-company-candidate-number-limit)))
 
 (provide 'helm-company)
 


### PR DESCRIPTION
Because the helm buffer size will vary depend on the current position of
point. At the bottom, the Helm window is really small. Using plain helm
function shows fixed size window.
